### PR TITLE
[BREAKING] Updated interface of REST API class:

### DIFF
--- a/dpl/api/rest_api.py
+++ b/dpl/api/rest_api.py
@@ -88,10 +88,12 @@ class RestApi(object):
         else:
             self._loop = loop
 
-    async def create_rest_server(self) -> None:
+    async def create_server(self, host: str, port: int) -> None:
         """
         Factory function that creates fully-functional aiohttp server,
         setups its routes and request handlers.
+        :param host: a server hostname or address
+        :param port: a server port
         :return: None
         """
         dispatcher = web.UrlDispatcher()
@@ -106,7 +108,14 @@ class RestApi(object):
         server = web.Server(handler=dproxy.dispatch)
 
         # TODO: Make server params configurable
-        await self._loop.create_server(server, host='localhost', port='10800')
+        await self._loop.create_server(server, host, port)
+
+    async def shutdown_server(self) -> None:
+        """
+        Stop (shutdown) REST server gracefully
+        :return: None
+        """
+        pass
 
     async def root_get_handler(self, request: web.Request) -> web.Response:
         """

--- a/dpl/core/controller.py
+++ b/dpl/core/controller.py
@@ -38,9 +38,9 @@ class Controller(object):
         self._auth_manager.create_root_user("admin", "admin")
 
         asyncio.ensure_future(
-            self._rest_api.create_rest_server()
+            self._rest_api.create_server(host='localhost', port=10800)
         )
 
     async def shutdown(self):
-        # await self._api_application.shutdown()
+        await self._rest_api.shutdown_server()
         self._pm.disable_all_things()


### PR DESCRIPTION
* renamed 'create_rest_server' coroutine to 'create_server'
* 'host' and 'port' values for server creation are now passed via arguments in 'create_server' (and are not hardcoded anymore)
* added a 'shutdown_server' coroutine, empty for now