### PR TITLE
Safe fetching for things and placements

### DIFF
--- a/dpl/api/api_gateway.py
+++ b/dpl/api/api_gateway.py
@@ -77,34 +77,36 @@ class ApiGateway(object):
 
         return result
 
-    def _get_thing(self, token: str, thing_id: str) -> Thing:
+    def _get_thing(self, token: str, thing_id: str, default=None) -> Thing:
         """
         Private method. Receive an instance of a specific thing
         :param token: access token
         :param thing_id: an ID of thing to be fetched
-        :return: an instance of Thing that is related to the specified ID
+        :param default: default value to be returned if the specified thing is not found
+        :return: an instance of Thing that is related to the specified ID or default value
         """
         # Check permission on viewing thing
         self._check_permission(token, None)
 
-        try:
-            thing = self._pm.fetch_thing(thing_id)
-        except KeyError as e:
-            raise exceptions.ThingNotFoundError("Thing with the specified id was not found") from e
+        thing = self._pm.fetch_thing(thing_id, default)
 
         return thing
 
-    def get_thing(self, token: str, thing_id: str) -> Dict:
+    def get_thing(self, token: str, thing_id: str, default=None) -> Dict:
         """
         Receive information about a specific thing
         :param token: access token
         :param thing_id: an ID of thing to be fetched
-        :return: a dict with full information about the thing
+        :param default: default value to be returned if the specified thing is not found
+        :return: a dict with full information about the thing or default value
         """
         # Permission on viewing of thing must be checked in '_get_thing' method
         # self._check_permission(token, None)
 
-        thing = self._get_thing(token, thing_id)
+        thing = self._get_thing(token, thing_id, None)
+
+        if thing is None:
+            return default
 
         return self._thing_to_dict(thing)
 
@@ -199,20 +201,21 @@ class ApiGateway(object):
 
         return result
 
-    def get_placement(self, token: str, placement_id: str) -> Dict:
+    def get_placement(self, token: str, placement_id: str, default=None) -> Dict:
         """
         Returns a dict-like representation of placement with the specified ID
         :param token: access token
         :param placement_id: an ID of placement to be fetched
-        :return: a dict with full information about the placement
+        :param default: default value to be returned if the specified placement is not found
+        :return: a dict with full information about the placement or default value
         """
         # FIXME: Check permission: View placements
         self._check_permission(token, None)
 
-        try:
-            placement = self._placements.fetch_placement(placement_id)
-        except KeyError as e:
-            raise exceptions.PlacementNotFoundError("The placement with the specified ID was not found") from e
+        placement = self._placements.fetch_placement(placement_id, None)
+
+        if placement is None:
+            return default
 
         return self._placement_to_dict_legacy(placement)
 

--- a/dpl/api/rest_api.py
+++ b/dpl/api/rest_api.py
@@ -269,11 +269,15 @@ class RestApi(object):
         thing_id = self._get_thing_id(request)
 
         try:
-            thing = self._gateway.get_thing(token, thing_id)
+            thing = self._gateway.get_thing(token, thing_id, default=None)
 
-            return make_json_response(thing)
         except PermissionError as e:
             return make_error_response(status=400, message=str(e))
+
+        if thing is None:
+            return make_error_response(status=404, message="A thing with the specified ID was not found")
+
+        return make_json_response(thing)
 
     @restricted_access_decorator
     async def placements_get_handler(self, request: web.Request, token: str = None) -> web.Response:
@@ -309,17 +313,18 @@ class RestApi(object):
         placement_id = self._get_placement_id(request)
 
         try:
-            return make_json_response(self._gateway.get_placement(token, placement_id))
-        except KeyError:
-            return make_error_response(
-                message="Failed to find a placement with the specified ID",
-                status=404
-            )
+            placement = self._gateway.get_placement(token, placement_id, default=None)
+
         except PermissionError:
             return make_error_response(
                 message="This token doesn't permit viewing of placement data",
                 status=403
             )
+
+        if placement is None:
+            return make_error_response(status=404, message="A placement with the specified ID was not found")
+
+        return make_json_response(placement)
 
     @restricted_access_decorator
     @json_decode_decorator

--- a/dpl/core/placement_manager.py
+++ b/dpl/core/placement_manager.py
@@ -39,11 +39,11 @@ class PlacementManager(object):
         """
         return self._placements.values()
 
-    def fetch_placement(self, placement_id: str) -> Placement:
+    def fetch_placement(self, placement_id: str, default=None) -> Placement:
         """
         Find specific placement by id
-        :param placement_id:
-        :return: an instance of Placement with the corresponding ID
-        :raises KeyValue: if the Placement with the specified ID was not found
+        :param placement_id: an ID of placement to be fetched
+        :param default: default value to be returned if the specified placement is not found
+        :return: an instance of Placement with the corresponding ID or default value
         """
-        return self._placements[placement_id]
+        return self._placements.get(placement_id, default)

--- a/dpl/core/platform_manager.py
+++ b/dpl/core/platform_manager.py
@@ -134,13 +134,14 @@ class PlatformManager(object):
         """
         return self._things.values()
 
-    def fetch_thing(self, thing_id: str) -> Thing:
+    def fetch_thing(self, thing_id: str, default=None) -> Thing:
         """
         Fetch an instance of Thing by its ID
         :param thing_id: an ID of Thing to be fetched
-        :return: an instance of Thing
+        :param default: default value to be returned if the specified thing is not found
+        :return: an instance of Thing or default value
         """
-        return self._things[thing_id]
+        return self._things.get(thing_id, default)
 
     def enable_all_things(self) -> None:
         """


### PR DESCRIPTION
A version of fetchers for Things and Placements that doesn't raise an exception if corresponding was not found by the specified ID. They return 'default' argument value instead of it (instead of raising exception).

This approach has upsides and downsides. As upside, it will work faster for handling of requests for non-existing data. As a downside, handling of requests for existing data objects is slightly slower.