### PR TITLE
Formatting fix for docstrings

### DIFF
--- a/dpl/api/api_gateway.py
+++ b/dpl/api/api_gateway.py
@@ -27,6 +27,7 @@ class ApiGateway(object):
     def auth(self, username: str, password: str) -> str:
         """
         Authenticate user and receive corresponding access token
+
         :param username: username of the user
         :param password: password of the user
         :return: an access token to be used
@@ -36,6 +37,7 @@ class ApiGateway(object):
     def _check_permission(self, token: str, requested_action):
         """
         Checks is specified action is permitted for this token
+
         :param token: access token to be checked
         :param requested_action: information about a requested action or permission
         :return: None
@@ -50,6 +52,7 @@ class ApiGateway(object):
 
         In addition to simple object -> dict serialization, the content of 'metadata'
         property will be moved to resulting dict body.
+
         :param thing: an instance of Thing to be converted
         :return: a corresponding dict
         """
@@ -64,6 +67,7 @@ class ApiGateway(object):
     def get_things(self, token: str) -> List[Dict]:
         """
         Receive a full list of data about things
+
         :param token: access token
         :return: a list of things data
         """
@@ -80,6 +84,7 @@ class ApiGateway(object):
     def _get_thing(self, token: str, thing_id: str) -> Thing:
         """
         Private method. Receive an instance of a specific thing
+
         :param token: access token
         :param thing_id: an ID of thing to be fetched
         :return: an instance of Thing that is related to the specified ID
@@ -97,6 +102,7 @@ class ApiGateway(object):
     def get_thing(self, token: str, thing_id: str) -> Dict:
         """
         Receive information about a specific thing
+
         :param token: access token
         :param thing_id: an ID of thing to be fetched
         :return: a dict with full information about the thing
@@ -113,6 +119,7 @@ class ApiGateway(object):
     def send_command(self, token: str, thing_id: str, command: str, *args, **kwargs):
         """
         Sends a command to specific thing with specified arguments
+
         :param token: access token
         :param thing_id: and ID of thing that must receive a specified command
         :param command: command to execute
@@ -145,6 +152,7 @@ class ApiGateway(object):
     def get_task_status(self, token: str, task_id):
         """
         Get a status of a planned task
+
         :param token: an access token
         :param task_id: some id or handler of task to be fetched
         :return: a status of the task
@@ -155,6 +163,7 @@ class ApiGateway(object):
     def _placement_to_dict(cls, placement: Placement) -> Dict:
         """
         Converts an instance of Placement to corresponding dictionary
+
         :return: a dictionary with all properties of placement
         """
         # FIXME: CC14: Consider switching to direct usage of properties
@@ -170,6 +179,7 @@ class ApiGateway(object):
         Converts an instance of Placement to corresponding dictionary that is compatible
         with the legacy API ('description' field will be set to the value of 'friendly_name' field,
         'image' field will be set to a value of 'image_url' field).
+
         :return: a dictionary with all properties of placement
         """
         warnings.warn("Legacy representation of placements will be dropped in the next release"
@@ -186,6 +196,7 @@ class ApiGateway(object):
     def get_placements(self, token: str) -> List[Dict]:
         """
         Returns a list of dict-like representations of all placements
+
         :param token: access token
         :return: a list of placements data
         """
@@ -202,6 +213,7 @@ class ApiGateway(object):
     def get_placement(self, token: str, placement_id: str) -> Dict:
         """
         Returns a dict-like representation of placement with the specified ID
+
         :param token: access token
         :param placement_id: an ID of placement to be fetched
         :return: a dict with full information about the placement

--- a/dpl/api/rest_api.py
+++ b/dpl/api/rest_api.py
@@ -43,6 +43,7 @@ def make_json_response(content: object, status: int = 200) -> web.Response:
     custom JSON encoders by default (functools.partial() may be used to create a
     corresponding callable which must to be passed into 'json_response' function
     as 'dumps' keyword argument).
+
     :param content: content to serialize
     :param status: status code of the response
     :return: created response
@@ -96,6 +97,7 @@ class RestApi(object):
         """
         Constructor. Receives a reference to API Gateway that will receive and process all
         command and data requests. Setups API routes and request handlers.
+
         :param gateway: an instance of ApiGateway
         """
         self._gateway = gateway
@@ -126,6 +128,7 @@ class RestApi(object):
     async def create_server(self, host: str, port: int) -> None:
         """
         Factory function that creates fully-functional aiohttp server
+
         :param host: a server hostname or address
         :param port: a server port
         :return: None
@@ -137,6 +140,7 @@ class RestApi(object):
         """
         Stop (shutdown) REST server gracefully.
         More info is available here: http://aiohttp.readthedocs.io/en/stable/web.html#aiohttp-web-graceful-shutdown
+
         :return: None
         """
         self._server.close()
@@ -149,6 +153,7 @@ class RestApi(object):
     async def _middleware_process_exceptions(app, handler):
         """
         Factory method that returns a handler coroutine for all unprocessed exceptions
+
         :param app: application that is related to this middleware
         :param handler: a handler to be wrapped; original request handler
         :return: a coroutine, middleware handler
@@ -188,6 +193,7 @@ class RestApi(object):
     async def root_get_handler(self, request: web.Request) -> web.Response:
         """
         A handler for GET requests to path='/'
+
         :param request: request to be processed
         :return: a response to request
         """
@@ -202,6 +208,7 @@ class RestApi(object):
     async def auth_post_handler(self, request: web.Request, json_data: dict = None) -> web.Response:
         """
         Primitive username and password validator
+
         :param request: request to be processed
         :param json_data: a content of request body
         :return: a response to request
@@ -230,6 +237,7 @@ class RestApi(object):
         A handler for OPTIONS request for path /auth.
 
         Returns a response that contains 'Allow' header with all allowed HTTP methods.
+
         :param request: request to be handled
         :return: a response to request
         """
@@ -243,6 +251,7 @@ class RestApi(object):
     async def things_get_handler(self, request: web.Request, token: str = None) -> web.Response:
         """
         A handler for GET requests for path /things/
+
         :param request: request to be processed
         :param token: an access token to be used, usually fetched by restricted_access_decorator
         :return: a response to request
@@ -263,6 +272,7 @@ class RestApi(object):
     async def thing_get_handler(self, request: web.Request, token: str = None) -> web.Response:
         """
         A handler for GET requests for path /things/
+
         :param request: request to be processed
         :param token: an access token to be used, usually fetched by restricted_access_decorator
         :return: a response to request
@@ -287,6 +297,7 @@ class RestApi(object):
     async def placements_get_handler(self, request: web.Request, token: str = None) -> web.Response:
         """
         A handler for GET requests for path /placements/
+
         :param request: request to be processed
         :param token: an access token to be used, usually fetched by restricted_access_decorator
         :return: a response to request
@@ -310,6 +321,7 @@ class RestApi(object):
     async def placement_get_handler(self, request: web.Request, token: str = None) -> web.Response:
         """
         A handler for GET requests for path /placements/
+
         :param request: request to be processed
         :param token: an access token to be used, usually fetched by restricted_access_decorator
         :return: a response to request
@@ -337,6 +349,7 @@ class RestApi(object):
         """
         ONLY FOR COMPATIBILITY: Accept 'action requested' messages from clients.
         Handle POST requests for /messages/ path.
+
         :param request: request to be processed
         :param token: an access token to be used, usually fetched by restricted_access_decorator
         :return: a response to request
@@ -426,6 +439,7 @@ class RestApi(object):
         A handler for OPTIONS request for path /messages/.
 
         Returns a response that contains 'Allow' header with all allowed HTTP methods.
+
         :param request: request to be handled
         :return: a response to request
         """

--- a/dpl/auth/auth_manager.py
+++ b/dpl/auth/auth_manager.py
@@ -22,6 +22,7 @@ class AuthManager(object):
     def users(self) -> Set[str]:
         """
         Returns a set of registered usernames
+
         :return: usernames of all registered users
         """
         # FIXME: CC7: Return just plain keys(), as is
@@ -31,6 +32,7 @@ class AuthManager(object):
     def create_root_user(self, username: str, password: str):
         """
         Create a root user if there is no users registered
+
         :param username: a username of root user
         :param password: a password of root user
         :return: None
@@ -50,6 +52,7 @@ class AuthManager(object):
     def create_user(self, token: str, username: str, password: str):
         """
         Create a user with specified username and password values
+
         :param token: an access token of a user that is trying to create a new one
         :param username: username of the user to be created
         :param password: password of the user to be created
@@ -69,6 +72,7 @@ class AuthManager(object):
         """
         Checks if user with specified token is authorized to create or remove users.
         Otherwise raises an exception.
+
         :param token: an access token of a user that is trying to create or remove another one
         :return: None
         """
@@ -84,6 +88,7 @@ class AuthManager(object):
     def remove_user(self, token: str, username: str):
         """
         Remove a user from the system
+
         :param token: an access token of a user that is trying to remove someone
         :param username: a username of the user to be removed
         :return: None
@@ -105,6 +110,7 @@ class AuthManager(object):
     def change_password(self, username: str, old_password: str, new_password: str):
         """
         Change a password of specific user
+
         :param username: a username of user whose password must be changed
         :param old_password: an old password of this user
         :param new_password: a new password of this user
@@ -123,6 +129,7 @@ class AuthManager(object):
     def _check_user_registered(self, username):
         """
         Checks if the user is registered in the system. Otherwise raises an exception
+
         :param username: username of user to be checked
         :return: None
         """
@@ -132,6 +139,7 @@ class AuthManager(object):
     def auth_user(self, username: str, password: str) -> str:
         """
         Authenticate the user and receive an access token for future usages
+
         :param username: username of user to be authenticated
         :param password: password of user to be authenticated
         :return: an access token
@@ -152,6 +160,7 @@ class AuthManager(object):
     def is_token_grants(self, token: str, requested_action: object) -> bool:
         """
         Check if specified token grants to perform the requested action
+
         :param token: an access token
         :param requested_action: an info about the requested action
         :return: true if permission is granted, false otherwise

--- a/dpl/auth/token_manager.py
+++ b/dpl/auth/token_manager.py
@@ -25,6 +25,7 @@ class TokenManager(object):
     def generate_token(self, token_owner) -> str:
         """
         Generates a new token for some User (or Client)
+
         :param token_owner: User or Client which is associated with token
         :return: a new token
         """
@@ -41,6 +42,7 @@ class TokenManager(object):
     def remove_token(self, token: str):
         """
         Revoke generated token
+
         :param token: a token to be revoked
         :return: None
         """
@@ -52,6 +54,7 @@ class TokenManager(object):
     def remove_all_tokens(self, token_owner):
         """
         Revoke all generated tokens for specific User or Client
+
         :param token_owner: User or Client which is associated with tokens to be revoked
         :return: None
         """
@@ -74,6 +77,7 @@ class TokenManager(object):
     def resolve_token_owner(self, token: str):
         """
         Determine an owner of specified token
+
         :param token: token to be resolved
         :return: an object of User or Client that owns the token
         """
@@ -82,6 +86,7 @@ class TokenManager(object):
     def is_token_present(self, token: str) -> bool:
         """
         Checks if the specified token is registered in the system
+
         :param token: token to be checked
         :return: true if token is registered, false otherwise
         """

--- a/dpl/auth/user.py
+++ b/dpl/auth/user.py
@@ -25,6 +25,7 @@ class User(object):
     def __init__(self, username: str, password: str):
         """
         Create a user of the system
+
         :param username: username to be used
         :param password: password to be used. NOT SAVED, just hashed
         """
@@ -37,6 +38,7 @@ class User(object):
     def username(self) -> str:
         """
         Returns a username of this user
+
         :return: username as a string
         """
         return self._username
@@ -45,6 +47,7 @@ class User(object):
     def username(self, value: str):
         """
         Updates the username of the user
+
         :param value: new username to be set
         :return: None
         """
@@ -57,6 +60,7 @@ class User(object):
     def _is_username_valid(username: str) -> bool:
         """
         Checks is the specified username is valid
+
         :param username: username to be checked
         :return: true if valid, false otherwise
         """
@@ -66,6 +70,7 @@ class User(object):
     def verify_password(self, password: str) -> bool:
         """
         Checks is the password is correct for this user
+
         :param password: password to be checked
         :return: true if password is correct and false otherwise
         """
@@ -74,6 +79,7 @@ class User(object):
     def update_password(self, old_password: str, new_password: str):
         """
         Updates current user password, raises an error if old_password is incorrect
+
         :param old_password: old password
         :param new_password: new password to be set
         :return: None

--- a/dpl/core/configuration.py
+++ b/dpl/core/configuration.py
@@ -42,6 +42,7 @@ class Configuration(object):
     def __init__(self, path: str):
         """
         Constructor which saves a path to configuration directory
+
         :param path: a path to configuration directory
         """
         check_dir_path(path)
@@ -53,6 +54,7 @@ class Configuration(object):
     def load_config(self) -> None:
         """
         Loads configuration from disk to memory
+
         :return: None
         """
         # TODO: REWRITE
@@ -76,6 +78,7 @@ class Configuration(object):
     def save_config(self) -> None:
         """
         Saves configuration on disk
+
         :return: None
         """
         raise NotImplementedError
@@ -83,6 +86,7 @@ class Configuration(object):
     def get_by_subsystem(self, subsystem_name: str) -> Dict or List[Dict]:
         """
         Returns a dict or list of config values that is related to specific subsystem
+
         :param subsystem_name: subsystem name for request
         :return: configuration values that are related to specified subsystem
         """

--- a/dpl/core/placement.py
+++ b/dpl/core/placement.py
@@ -8,6 +8,7 @@ class Placement(object):
     def __init__(self, placement_id: str, friendly_name: str = None, image_url: str = None):
         """
         Constructor
+
         :param placement_id: some unique identifier of this entity
         :param friendly_name: human-friendly name of this placement
         :param image_url: an URL to the illustration image
@@ -21,6 +22,7 @@ class Placement(object):
     def placement_id(self) -> str:
         """
         Contains an unique identifier of this entity. Can't be changed after init.
+
         :return: string, system-internal identifier
         """
         return self._placement_id
@@ -29,6 +31,7 @@ class Placement(object):
     def friendly_name(self) -> str:
         """
         Contains some short meaningful human-readable naming of this placement
+
         :return: string, placement's name
         """
         return self._friendly_name
@@ -37,6 +40,7 @@ class Placement(object):
     def friendly_name(self, new_value: str):
         """
         A setter for friendly_name property
+
         :param new_value: new value of name to be set
         :return: None
         """
@@ -47,6 +51,7 @@ class Placement(object):
     def image_url(self) -> str:
         """
         Stores an URL to the illustration image for this placement
+
         :return: string representation of URL
         """
         return self._image_url
@@ -55,6 +60,7 @@ class Placement(object):
     def image_url(self, new_value: str):
         """
         A setter for image_url property
+
         :param new_value: new value to be set
         :return: None
         """

--- a/dpl/core/placement_manager.py
+++ b/dpl/core/placement_manager.py
@@ -20,6 +20,7 @@ class PlacementManager(object):
     def init_placements(self, config: List[Dict]) -> None:
         """
         Init all placements by a specified configuration data
+
         :param config: configuration data that will be used for building of Placements
         :return: None
         """
@@ -35,6 +36,7 @@ class PlacementManager(object):
     def fetch_all_placements(self) -> ValuesView[Placement]:
         """
         Fetch a set-like collection of all stored Placements
+
         :return: a set-like collection of Placements
         """
         return self._placements.values()
@@ -42,6 +44,7 @@ class PlacementManager(object):
     def fetch_placement(self, placement_id: str) -> Placement:
         """
         Find specific placement by id
+
         :param placement_id:
         :return: an instance of Placement with the corresponding ID
         :raises KeyValue: if the Placement with the specified ID was not found

--- a/dpl/platforms/connection_factory.py
+++ b/dpl/platforms/connection_factory.py
@@ -13,6 +13,7 @@ class ConnectionFactory(object):
     def build(*args, **kwargs) -> Connection:
         """
         Build: create a specific instance of connection by specified params
+
         :param args: positional arguments
         :param kwargs: keyword arguments
         :return: an instance of Connection

--- a/dpl/platforms/connection_registry.py
+++ b/dpl/platforms/connection_registry.py
@@ -17,6 +17,7 @@ class ConnectionRegistry(object):
         # FIXME: CC10: Add additional platform argument?
         """
         Register a factory for building of instance of corresponding connection type
+
         :param connection_type: a name of connection type, for which connection factory
             is registered.
         :param factory: an instance of connection factory that will be used for building
@@ -30,6 +31,7 @@ class ConnectionRegistry(object):
         """
         Returns an instance of ConnectionFactory that must be used for building of
         specified type of connections.
+
         :param connection_type: a type of connection that ConnectionFactory is responsible for.
         :param default: object to be returned if related ConnectionFactory is not found
         :return: an instance of ConnectionFactory or None if it's not found
@@ -40,6 +42,7 @@ class ConnectionRegistry(object):
     def remove_factory(cls, connection_type: str) -> None:
         """
         Removes an instance of connection factory, that is associated with specified connection type
+
         :param connection_type: a type of connection that ConnectionFactory was responsible for
         :return: None
         """

--- a/dpl/platforms/dummy/dummy_connection.py
+++ b/dpl/platforms/dummy/dummy_connection.py
@@ -17,6 +17,7 @@ class DummyConnection(Connection):
         """
         Constructor receives a file or file-like object that will be used for printing.
         sys.stdout will be used by default
+
         :param file: file-like object (stream) that will be used for printing
         """
         self._file = file
@@ -24,6 +25,7 @@ class DummyConnection(Connection):
     def print(self, prefix: str, data: Any) -> None:
         """
         Print some data to file/console with a specified prefix
+
         :param data: data to be printed
         :param prefix: prefix to be printed before the specified data
         :return: None

--- a/dpl/platforms/dummy/dummy_player.py
+++ b/dpl/platforms/dummy/dummy_player.py
@@ -15,6 +15,7 @@ class DummyPlayer(Player):
         """
         Constructor. Receives an instance of DummyConnection and a prefix to be printed
         in con_params.
+
         :param con_instance: an instance of connection to be used
         :param con_params: a dict which contains connection access params
         :param metadata: some additional data that will be saved to 'metadata' property
@@ -35,6 +36,7 @@ class DummyPlayer(Player):
     def state(self) -> Player.States:
         """
         Return a current state of the Thing
+
         :return: an instance of self.State
         """
         return self._state
@@ -43,6 +45,7 @@ class DummyPlayer(Player):
     def is_available(self) -> bool:
         """
         Availability of thing for usage and communication
+
         :return: True if Thing is available, False otherwise
         """
         return self._is_enabled  # and self._connection.is_connected
@@ -51,6 +54,7 @@ class DummyPlayer(Player):
     def last_updated(self) -> float:
         """
         Returns a timestamp of the last thing state update
+
         :return: float, UNIX time
         """
         return self._last_updated
@@ -62,6 +66,7 @@ class DummyPlayer(Player):
         everything on its own. Devices are allowed to switch to standby
         or power-saving mode. Thing 'state' property reflects only last
         known state of the physical object.
+
         :return: None
         """
         self._is_enabled = False
@@ -71,6 +76,7 @@ class DummyPlayer(Player):
         Allows communication with a physical object. Initiates a process
         of establishing connection to the physical device. Makes physical
         device to "wake up", to start receiving commands and sending of data.
+
         :return: None
         """
         self._is_enabled = True
@@ -79,6 +85,7 @@ class DummyPlayer(Player):
         """
         Starts playing and switches the object to the 'playing' state. Additional parameters
         like track name or URL can be provided.
+
         :param song_name: song name to be played (or URL, or ID, or playlist position, etc.)
         :return: None
         """
@@ -89,6 +96,7 @@ class DummyPlayer(Player):
     def stop(self) -> None:
         """
         Stops playing and switches the object to the 'stopped' state.
+
         :return: None
         """
         self._check_is_available()
@@ -98,6 +106,7 @@ class DummyPlayer(Player):
     def pause(self) -> None:
         """
         Pause playing and switches the object to the 'paused' state.
+
         :return: None
         """
         self._check_is_available()

--- a/dpl/platforms/dummy/dummy_slider.py
+++ b/dpl/platforms/dummy/dummy_slider.py
@@ -18,6 +18,7 @@ class DummySlider(Slider):
         """
         Constructor. Receives an instance of DummyConnection and a prefix to be printed
         in con_params.
+
         :param con_instance: an instance of connection to be used
         :param con_params: a dict which contains connection access params
         :param metadata: some additional data that will be saved to 'metadata' property
@@ -38,6 +39,7 @@ class DummySlider(Slider):
     def state(self) -> Slider.States:
         """
         Return a current state of the Thing
+
         :return: an instance of self.State
         """
         return self._state
@@ -46,6 +48,7 @@ class DummySlider(Slider):
     def is_available(self) -> bool:
         """
         Availability of thing for usage and communication
+
         :return: True if Thing is available, False otherwise
         """
         return self._is_enabled  # and self._connection.is_connected
@@ -54,6 +57,7 @@ class DummySlider(Slider):
     def last_updated(self) -> float:
         """
         Returns a timestamp of the last thing state update
+
         :return: float, UNIX time
         """
         return self._last_updated
@@ -65,6 +69,7 @@ class DummySlider(Slider):
         everything on its own. Devices are allowed to switch to standby
         or power-saving mode. Thing 'state' property reflects only last
         known state of the physical object.
+
         :return: None
         """
         self._is_enabled = False
@@ -74,6 +79,7 @@ class DummySlider(Slider):
         Allows communication with a physical object. Initiates a process
         of establishing connection to the physical device. Makes physical
         device to "wake up", to start receiving commands and sending of data.
+
         :return: None
         """
         self._is_enabled = True
@@ -82,6 +88,7 @@ class DummySlider(Slider):
         """
         Switches an object to the 'opening' and then 'opened' state if its current state
         is 'undefined', 'closed' or 'closing'. Command must be ignored otherwise.
+
         :return: None
         """
         self._check_is_available()
@@ -101,6 +108,7 @@ class DummySlider(Slider):
         """
         Switches an object to the 'closing' and then 'closed' state if its current state
         is 'undefined', 'opened' or 'opening'. Command must be ignored otherwise.
+
         :return: None
         """
         self._check_is_available()

--- a/dpl/platforms/dummy/dummy_switch.py
+++ b/dpl/platforms/dummy/dummy_switch.py
@@ -12,6 +12,7 @@ class DummySwitch(Switch):
         """
         Constructor. Receives an instance of DummyConnection and a prefix to be printed
         in con_params.
+
         :param con_instance: an instance of connection to be used
         :param con_params: a dict which contains connection access params
         :param metadata: some additional data that will be saved to 'metadata' property
@@ -32,6 +33,7 @@ class DummySwitch(Switch):
     def state(self) -> Switch.States:
         """
         Return a current state of the Thing
+
         :return: an instance of self.State
         """
         return self._state
@@ -40,6 +42,7 @@ class DummySwitch(Switch):
     def is_available(self) -> bool:
         """
         Availability of thing for usage and communication
+
         :return: True if Thing is available, False otherwise
         """
         return self._is_enabled  # and self._connection.is_connected
@@ -48,6 +51,7 @@ class DummySwitch(Switch):
     def last_updated(self) -> float:
         """
         Returns a timestamp of the last thing state update
+
         :return: float, UNIX time
         """
         return self._last_updated
@@ -59,6 +63,7 @@ class DummySwitch(Switch):
         everything on its own. Devices are allowed to switch to standby
         or power-saving mode. Thing 'state' property reflects only last
         known state of the physical object.
+
         :return: None
         """
         self._is_enabled = False
@@ -68,6 +73,7 @@ class DummySwitch(Switch):
         Allows communication with a physical object. Initiates a process
         of establishing connection to the physical device. Makes physical
         device to "wake up", to start receiving commands and sending of data.
+
         :return: None
         """
         self._is_enabled = True
@@ -75,6 +81,7 @@ class DummySwitch(Switch):
     def on(self) -> None:
         """
         Switches an object to the 'on' state
+
         :return: None
         """
         self._check_is_available()
@@ -84,6 +91,7 @@ class DummySwitch(Switch):
     def off(self) -> None:
         """
         Switches an object to the 'off' state
+
         :return: None
         """
         self._check_is_available()

--- a/dpl/platforms/platform_manager.py
+++ b/dpl/platforms/platform_manager.py
@@ -30,6 +30,7 @@ class PlatformManager(object):
     def init_platforms(self, platform_names: List[str]) -> None:
         """
         Load all enabled platforms from the specified list
+
         :param platform_names: a name of platforms to be loaded
         :return: None
         """
@@ -43,6 +44,7 @@ class PlatformManager(object):
     def init_connections(self, config: List[Dict]) -> None:
         """
         Initialize all connections by configuration data
+
         :param config: configuration data
         :return: None
         """
@@ -76,6 +78,7 @@ class PlatformManager(object):
     def init_things(self, config: List[Dict]) -> None:
         """
         Initialize all things by configuration data
+
         :param config: configuration data
         :return: None
         """
@@ -128,6 +131,7 @@ class PlatformManager(object):
     def fetch_all_things(self) -> ValuesView[Thing]:
         """
         Fetch a collection of all things
+
         :return: a set-like object containing all things
         """
         return self._things.values()
@@ -135,6 +139,7 @@ class PlatformManager(object):
     def fetch_thing(self, thing_id: str) -> Thing:
         """
         Fetch an instance of Thing by its ID
+
         :param thing_id: an ID of Thing to be fetched
         :return: an instance of Thing
         """
@@ -143,6 +148,7 @@ class PlatformManager(object):
     def enable_all_things(self) -> None:
         """
         Call Thing.enable method on all instances of things
+
         :return: None
         """
         for thing in self._things.values():
@@ -151,6 +157,7 @@ class PlatformManager(object):
     def disable_all_things(self) -> None:
         """
         Call Thing.enable method on all instances of things
+
         :return: None
         """
         for thing in self._things.values():

--- a/dpl/platforms/thing_factory.py
+++ b/dpl/platforms/thing_factory.py
@@ -13,6 +13,7 @@ class ThingFactory(object):
     def build(*args, **kwargs) -> Thing:
         """
         Build: create a specific instance of thing by specified params
+
         :param args: positional arguments
         :param kwargs: keyword arguments
         :return: an instance of Thing

--- a/dpl/platforms/thing_registry.py
+++ b/dpl/platforms/thing_registry.py
@@ -19,6 +19,7 @@ class ThingRegistry(object):
     def register_factory(cls, platform_name: str, thing_type: str, factory: ThingFactory) -> None:
         """
         Register a factory for building of instance of corresponding thing type
+
         :param platform_name: a name of platform to which this ThingFactory belongs
         :param thing_type: a name of thing type, for which thing factory is registered.
         :param factory: an instance of thing factory that will be used for building
@@ -35,6 +36,7 @@ class ThingRegistry(object):
         """
         Returns an instance of ThingFactory that must be used for building of
         specified type of things.
+
         :param platform_name: a name of platform to which this ThingFactory belongs
         :param thing_type: a type of thing that ThingFactory is responsible for
         :param default: object to be returned if related ThingFactory is not found
@@ -48,6 +50,7 @@ class ThingRegistry(object):
     def remove_factory(cls, platform_name: str, thing_type: str) -> None:
         """
         Removes an instance of thing factory, that is associated with specified thing type
+
         :param platform_name: a name of platform to which this ThingFactory belongs
         :param thing_type: a type of thing that ThingFactory was responsible for
         :return: None

--- a/dpl/run.py
+++ b/dpl/run.py
@@ -18,6 +18,7 @@ LOGGER = logging.getLogger(__name__)
 def shutdown(loop: asyncio.AbstractEventLoop = None):
     """
     Shutdown: Cancel all pending tasks and wait for them to complete
+
     :param loop: EventLoop where tasks are running in
     :return: None
     """
@@ -37,6 +38,7 @@ def shutdown(loop: asyncio.AbstractEventLoop = None):
 def main():
     """
     Main function of the application
+
     :return: None
     """
     loop = asyncio.get_event_loop()

--- a/dpl/things/actuator.py
+++ b/dpl/things/actuator.py
@@ -29,6 +29,7 @@ class Actuator(Thing):
     def commands(self) -> Tuple[str, ...]:
         """
         Returns a list of available commands. Must be overridden in derivative classes.
+
         :return: a tuple of command names (strings)
         """
         return 'activate', 'deactivate', 'toggle'
@@ -37,6 +38,7 @@ class Actuator(Thing):
     def is_active(self) -> bool:
         """
         Returns an activation flag
+
         :return: true if object is in any 'active' state, false otherwise
         """
         raise NotImplementedError
@@ -45,6 +47,7 @@ class Actuator(Thing):
     def execute(self, command: str, *args, **kwargs) -> None:
         """
         Executes a command with 'command' name and specified arguments
+
         :param command: a name of command to be executed
         :param args: positional arguments to be passed
         :param kwargs: keyword arguments to be passed
@@ -62,6 +65,7 @@ class Actuator(Thing):
     def activate(self) -> None:
         """
         Turns an object to some specific 'active' state
+
         :return: None
         """
         raise NotImplementedError
@@ -69,6 +73,7 @@ class Actuator(Thing):
     def deactivate(self) -> None:
         """
         Turns an object to some specific 'inactive' state
+
         :return: None
         """
         raise NotImplementedError
@@ -76,6 +81,7 @@ class Actuator(Thing):
     def toggle(self) -> None:
         """
         Switches an object from the current state to the opposite one
+
         :return: None
         """
         if self.is_active:

--- a/dpl/things/player.py
+++ b/dpl/things/player.py
@@ -22,6 +22,7 @@ class Player(Actuator):
     def commands(self) -> Tuple[str, ...]:
         """
         Returns a list of available commands. Must be overridden in derivative classes.
+
         :return: a tuple of command names (strings)
         """
         return super().commands + ('stop', 'play', 'pause')
@@ -30,6 +31,7 @@ class Player(Actuator):
     def is_active(self):
         """
         Indicates if the object is in active state
+
         :return: True if state == 'on', false otherwise
         """
         return self.state == self.States.playing
@@ -37,6 +39,7 @@ class Player(Actuator):
     def activate(self) -> None:
         """
         Switches an object to the active ('playing') state
+
         :return: None
         """
         return self.play()
@@ -44,6 +47,7 @@ class Player(Actuator):
     def deactivate(self) -> None:
         """
         Switches an object to the inactive ('paused') state
+
         :return: None
         """
         return self.pause()
@@ -52,6 +56,7 @@ class Player(Actuator):
         """
         Starts playing and switches the object to the 'playing' state. Additional parameters
         like track name or URL can be provided.
+
         :param args: positional parameters
         :param kwargs: keyword parameters
         :return: None
@@ -61,6 +66,7 @@ class Player(Actuator):
     def stop(self) -> None:
         """
         Stops playing and switches the object to the 'stopped' state.
+
         :return: None
         """
         raise NotImplementedError
@@ -68,6 +74,7 @@ class Player(Actuator):
     def pause(self) -> None:
         """
         Pause playing and switches the object to the 'paused' state.
+
         :return: None
         """
         raise NotImplementedError

--- a/dpl/things/slider.py
+++ b/dpl/things/slider.py
@@ -24,6 +24,7 @@ class Slider(Actuator):
     def commands(self) -> Tuple[str, ...]:
         """
         Returns a list of available commands. Must be overridden in derivative classes.
+
         :return: a tuple of command names (strings)
         """
         return super().commands + ('open', 'close')
@@ -32,6 +33,7 @@ class Slider(Actuator):
     def is_active(self):
         """
         Indicates if the object is in active state
+
         :return: True if state == 'on', false otherwise
         """
         return self.state == self.States.opened
@@ -39,6 +41,7 @@ class Slider(Actuator):
     def activate(self) -> None:
         """
         Switches an object to the active ('opened') state
+
         :return: None
         """
         return self.open()
@@ -46,6 +49,7 @@ class Slider(Actuator):
     def deactivate(self) -> None:
         """
         Switches an object to the inactive ('closed') state
+
         :return: None
         """
         return self.close()
@@ -54,6 +58,7 @@ class Slider(Actuator):
         """
         Switches an object to the 'opening' and then 'opened' state if its current state
         is 'undefined', 'closed' or 'closing'. Command must be ignored otherwise.
+
         :return: None
         """
         raise NotImplementedError
@@ -62,6 +67,7 @@ class Slider(Actuator):
         """
         Switches an object to the 'closing' and then 'closed' state if its current state
         is 'undefined', 'opened' or 'opening'. Command must be ignored otherwise.
+
         :return: None
         """
         raise NotImplementedError

--- a/dpl/things/switch.py
+++ b/dpl/things/switch.py
@@ -21,6 +21,7 @@ class Switch(Actuator):
     def commands(self) -> Tuple[str, ...]:
         """
         Returns a list of available commands. Must be overridden in derivative classes.
+
         :return: a tuple of command names (strings)
         """
         return super().commands + ('on', 'off')
@@ -29,6 +30,7 @@ class Switch(Actuator):
     def is_active(self):
         """
         Indicates if the object is in active state
+
         :return: True if state == 'on', false otherwise
         """
         return self.state == self.States.on
@@ -36,6 +38,7 @@ class Switch(Actuator):
     def activate(self) -> None:
         """
         Switches an object to the active ('on') state
+
         :return: None
         """
         return self.on()
@@ -43,6 +46,7 @@ class Switch(Actuator):
     def deactivate(self) -> None:
         """
         Switches an object to the inactive ('off') state
+
         :return: None
         """
         return self.off()
@@ -50,6 +54,7 @@ class Switch(Actuator):
     def on(self) -> None:
         """
         Switches an object to the 'on' state
+
         :return: None
         """
         raise NotImplementedError
@@ -57,6 +62,7 @@ class Switch(Actuator):
     def off(self) -> None:
         """
         Switches an object to the 'off' state
+
         :return: None
         """
         raise NotImplementedError

--- a/dpl/things/thing.py
+++ b/dpl/things/thing.py
@@ -53,6 +53,7 @@ class Thing(object):
         Constructor of a Thing. Receives an instance of Connection and some specific
         parameters to use it properly. Also can receive some metadata to be stored like
         object placement, description or user-friendly name.
+
         :param con_instance: an instance of connection to be used
         :param con_params: parameters to access connection
         :param metadata: metadata to be stored
@@ -67,6 +68,7 @@ class Thing(object):
     def metadata(self) -> dict:
         """
         Returns a stored metadata
+
         :return: metadata of objects
         """
         return self._metadata
@@ -75,6 +77,7 @@ class Thing(object):
     def state(self) -> States:
         """
         Return a current state of the Thing
+
         :return: an instance of self.State
         """
         raise NotImplementedError
@@ -83,6 +86,7 @@ class Thing(object):
     def _state(self) -> States:
         """
         Return a really_internal_state_value
+
         :return: an instance of self.State
         """
         return self._really_internal_state_value
@@ -92,6 +96,7 @@ class Thing(object):
         """
         Internal setter for a really_internal_state_value that can be used to
         set a new state value and update last_updated time
+
         :param new_value: new state value to be set
         :return: None
         """
@@ -102,6 +107,7 @@ class Thing(object):
     def is_available(self) -> bool:
         """
         Availability of thing for usage and communication
+
         :return: True if Thing is available, False otherwise
         """
         raise NotImplementedError
@@ -110,6 +116,7 @@ class Thing(object):
     def last_updated(self) -> float:
         """
         Returns a timestamp of the last thing state update
+
         :return: float, UNIX time
         """
         return self._last_updated
@@ -121,6 +128,7 @@ class Thing(object):
         everything on its own. Devices are allowed to switch to standby
         or power-saving mode. Thing 'state' property reflects only last
         known state of the physical object.
+
         :return: None
         """
         raise NotImplementedError
@@ -130,6 +138,7 @@ class Thing(object):
         Allows communication with a physical object. Initiates a process
         of establishing connection to the physical device. Makes physical
         device to "wake up", to start receiving commands and sending of data.
+
         :return: None
         """
         raise NotImplementedError
@@ -137,6 +146,7 @@ class Thing(object):
     def _check_is_available(self) -> None:
         """
         Checks if this thing is available and raises and exception otherwise
+
         :return: None
         """
         if not self.is_available:

--- a/dpl/utils/generate_token.py
+++ b/dpl/utils/generate_token.py
@@ -5,6 +5,7 @@ import binascii
 def generate_token(length: int = 40) -> bytes:
     """
     Generates a random token with a specified length
+
     :return: bytes-encoded string
     """
     n_of_bytes = length // 2

--- a/dpl/utils/json_enum_encoder.py
+++ b/dpl/utils/json_enum_encoder.py
@@ -13,6 +13,7 @@ class JsonEnumEncoder(json.JSONEncoder):
         Redefine 'default' method of JSONEncoder:
             if object is enum variable - use it's name as value
             else - try to serialize with default json encoder
+
         :param obj: object to be serialized
         :return: a string representation of specified object
         """

--- a/dpl/utils/obj_to_dict.py
+++ b/dpl/utils/obj_to_dict.py
@@ -9,6 +9,7 @@ def obj_to_dict(o: object) -> Dict[str, Any]:
     """
     Serialize any python object to dictionary. It walks across all public properties
     of an object and saves their values into dictionary
+
     :param o: an object to be serialized
     :return: a dictionary where keys = property names and values = property values
     """


### PR DESCRIPTION
Added a new line in between of method description and its params for each docstring in ADPL. That change made docstrings valid according to reST docstring style: https://stackoverflow.com/questions/3898572/what-is-the-standard-python-docstring-format