### PR TITLE
Introduced HTTP API provider, moved REST API root

### DIFF
--- a/docs/source/api/rest_api.rst
+++ b/docs/source/api/rest_api.rst
@@ -19,9 +19,18 @@ path. Keep in mind that the hostname and port of platform instance
 can be changed in various circumstances (like ip address renewal,
 moving between different networks and so on).
 
-The ``BASE_URL`` may look like this: ``http://localhost:10800/api/v1/``
+The ``BASE_URL`` always look like:
+``protocol://domain:port/api/rest/v1``
 
-or like this: ``https://hostname.local/api/v1/``
+Where:
+
+- ``protocol`` is either ``http`` or ``https`` for unsecured and
+  secured (TLS) HTTP connection;
+- ``domain`` is a fully-qualified domain name or IP address of evepl
+  instance you are connecting to;
+- ``port`` is a port used for HTTP connection;
+- ``api/rest/`` is a constant part of an address;
+- ``v1`` indicates the currently used version of the REST API.
 
 .. _protected_resources:
 

--- a/dpl/api/http_api_provider.py
+++ b/dpl/api/http_api_provider.py
@@ -1,0 +1,63 @@
+"""
+This module contains a base HTTP API Provider implementation. This provider
+is only used to merge different HTTP-based API providers under the same domain
+"""
+import asyncio
+
+from aiohttp import web
+
+
+class HttpApiProvider(object):
+    """
+    This class contains a base HTTP provider to be used
+    """
+
+    def __init__(self, loop: asyncio.AbstractEventLoop = None):
+        if loop is None:
+            self._loop = asyncio.get_event_loop()
+        else:
+            self._loop = loop
+
+        self._handler = None
+        self._server = None
+
+        self._app = web.Application()
+
+    def add_child_provider(self, provider, provider_root: str) -> None:
+        """
+        Assigns the specified address to the specified API provider
+
+        :param provider: an child API provider to be registered
+        :param provider_root: an address where this provider will be installed
+        :return: None
+        """
+        self._app.add_subapp(
+            provider_root, provider.app
+        )
+
+    async def create_server(self, host: str, port: int) -> None:
+        """
+        Factory function that creates fully-functional aiohttp server
+
+        :param host: a server hostname or address
+        :param port: a server port
+        :return: None
+        """
+        self._handler = self._app.make_handler(loop=self._loop)
+        self._server = await self._loop.create_server(
+            self._handler, host, port
+        )
+
+    async def shutdown_server(self) -> None:
+        """
+        Stop (shutdown) REST server gracefully.
+        More info is available here: https://goo.gl/eNviyZ
+        :return: None
+        """
+        self._server.close()
+        await self._server.wait_closed()
+        # fires on_shutdown signal (so does nothing now)
+        await self._app.shutdown()
+        await self._handler.shutdown(60.0)
+        # fires on_cleanup signal (so does nothing now)
+        await self._app.cleanup()

--- a/dpl/api/rest_api/rest_api_provider.py
+++ b/dpl/api/rest_api/rest_api_provider.py
@@ -124,6 +124,15 @@ class RestApiProvider(object):
         self._router.add_post(path='/auth', handler=auth_post_handler)
         self._router.add_route(method='OPTIONS', path='/auth', handler=auth_options_handler)
 
+    @property
+    def app(self) -> web.Application:
+        """
+        Returns the underlying aiohttp.web Application
+
+        :return: the underlying aiohttp.web Application
+        """
+        return self._app
+
     async def create_server(self, host: str, port: int) -> None:
         """
         Factory function that creates fully-functional aiohttp server


### PR DESCRIPTION
This pull request introduces the new HTTP API provider that will handle HTTP connections to the platform and redirect requests to the corresponding child API providers.

Also this pull request changes the placement of REST API from domain root (`/`) to `/api/rest/v1/`

Related to #13, Closes #100 