### PR TITLE
Metaclass conflict workaround for Has Value capability

### DIFF
--- a/dpl/integrations/base_things/abs_binary_sensor.py
+++ b/dpl/integrations/base_things/abs_binary_sensor.py
@@ -5,7 +5,7 @@ from dpl.things.capabilities import IsActive
 from .abs_value_sensor import AbsValueSensor
 
 
-class AbsBinarySensor(AbsValueSensor[bool], IsActive):
+class AbsBinarySensor(AbsValueSensor, IsActive):
     """
     The most primitive (but not necessary the base) type of Sensors in the
     system. Can have only one of two integer values: 1 and 0. Where 1 is

--- a/dpl/integrations/base_things/abs_value_sensor.py
+++ b/dpl/integrations/base_things/abs_value_sensor.py
@@ -1,15 +1,11 @@
 # Include standard modules
-from typing import TypeVar
-
 # Include 3rd-party modules
 # Include DPL modules
 from dpl.things.thing import Thing
 from dpl.things.capabilities import HasValue
 
-T = TypeVar('T')
 
-
-class AbsValueSensor(Thing, HasValue[T]):
+class AbsValueSensor(Thing, HasValue):
     """
     A generic type of sensors which represent their results of measurements
     in numbers of an unspecified unit. Must to be used rarely, only if

--- a/dpl/things/capabilities/has_value.py
+++ b/dpl/things/capabilities/has_value.py
@@ -1,9 +1,4 @@
-from typing import TypeVar, Generic, Optional
-
-TValueType = TypeVar('TValueType')
-
-
-class HasValue(Generic[TValueType]):
+class HasValue(object):
     """
     Objects with HasValue capability are usually mapped to
     sensors. They allow to read the current measurements
@@ -13,7 +8,7 @@ class HasValue(Generic[TValueType]):
     _capability_name = 'has_value'
 
     @property
-    def value(self) -> Optional[TValueType]:
+    def value(self):
         """
         Returns the current (last known for unavailable
         state) value read from the internal sensors. Or


### PR DESCRIPTION
Has Value capability was implemented as a generic class, a child of a Generic class from Python typing module. Unfortunately, Generic class is implemented using a non-trivial GenericMeta metaclass which in combination with user-declared metaclasses results in a metaclass conflict.

To workaround (but not fix) this problem it was decided to make a HasValue class usual, non-generic class. But the real fix will be possible only when PEP 560 will be supported by the current version of Python (i.e. starting from Python 3.7).

Another workaround: create a new metaclass that will inherit from GenericMeta or modify existing metaclasses to do so.

More info:
- PEP 560: https://www.python.org/dev/peps/pep-0560/
- a similar issue: https://github.com/python/typing/issues/449

Follow-up for #117